### PR TITLE
Update exec.sh to allow override of HTTP_ variables from environment

### DIFF
--- a/exec.sh
+++ b/exec.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+HTTP_PORT=${HTTP_PORT:-3000}
+HTTPS_PORT=${HTTPS_PORT:-3443}
+HTTP_ALL_INTERFACES=${HTTP_ALL_INTERFACES:-no}
+
 /usr/sbin/zerotier-one &
 
 while [ ! -f /var/lib/zerotier-one/authtoken.secret ]; do
@@ -8,4 +12,9 @@ done
 chmod g+r /var/lib/zerotier-one/authtoken.secret
 
 cd /opt/key-networks/ztncui
+
+echo "HTTPS_PORT=$HTTPS_PORT" > /opt/key-networks/ztncui/.env
+echo "HTTP_PORT=$HTTP_PORT" >> /opt/key-networks/ztncui/.env
+echo "HTTP_ALL_INTERFACES=$HTTP_ALL_INTERFACES" >> /opt/key-networks/ztncui/.env
+
 exec sudo -u ztncui /opt/key-networks/ztncui/ztncui


### PR DESCRIPTION
While it is allowed to send env variables such as HTTP_PORT, these do not get written to the /opt/key-networks/ztncui/.env file, and therefore have no effect. This PR changes exec.sh so that it will set the default values, unless the env is set.